### PR TITLE
feat: install thin-edge.io 1.4.1 by default

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ fi
 
 # Installation settings
 CHANNEL=release
-VERSION="1.3.0"
+VERSION="1.4.1"
 
 IDENTITY_PREFIX=${IDENTITY_PREFIX:-actia_}
 IDENTITY_SCRIPT=/media/maps/regatta/bin/sn.sh


### PR DESCRIPTION
Checkout the thin-edge.io [release notes](https://github.com/thin-edge/thin-edge.io/releases) for more details.