### PR TITLE
feat: install thin-edge.io 1.5.0 by default

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ fi
 
 # Installation settings
 CHANNEL=release
-VERSION="1.4.2"
+VERSION="1.5.0"
 
 IDENTITY_PREFIX=${IDENTITY_PREFIX:-actia_}
 IDENTITY_SCRIPT=/media/maps/regatta/bin/sn.sh


### PR DESCRIPTION
Install thin-edge.io 1.5.0 by default