### PR TITLE
feat: add certificate renewer service

### DIFF
--- a/etc/systemd/system/tedge-cert-renewer.target
+++ b/etc/systemd/system/tedge-cert-renewer.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=thin-edge.io certificate renewal

--- a/etc/systemd/system/tedge-cert-renewer@.service
+++ b/etc/systemd/system/tedge-cert-renewer@.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=thin-edge.io certificate renewer for %I
+After=network-online.target
+StartLimitIntervalSec=0
+PartOf=tedge-cert-renewer.target
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=/media/apps/com.thin-edge.app/environment
+
+Environment=RENEW_WITH_CA=c8y
+
+; Only run service is if the certificate needs renewal
+ExecCondition=/media/apps/com.thin-edge.app/bin/tedge cert needs-renewal %i
+
+; Run renewal
+ExecStartPre=/media/apps/com.thin-edge.app/bin/tedge cert renew %i --ca ${RENEW_WITH_CA}
+
+; Reconnect
+ExecStart=/media/apps/com.thin-edge.app/bin/tedge reconnect %i
+
+; Cleanup
+ExecStopPost=sh -c 'rm -f "$(/media/apps/com.thin-edge.app/bin/tedge config get %i.device.cert_path).new"'
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/tedge-cert-renewer@.timer
+++ b/etc/systemd/system/tedge-cert-renewer@.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Timer for thin-edge.io certificate renewal for c8y (profile=%i)
+Documentation=https://thin-edge.io
+PartOf=tedge-cert-renewer-c8y.target
+
+[Timer]
+Persistent=true
+
+; Timer interval
+OnCalendar=hourly
+
+; Always run the timer on time
+AccuracySec=1us
+
+; Add jitter to prevent a "thundering herd" of simultaneous certificate renewals
+RandomizedDelaySec=5m
+
+[Install]
+WantedBy=timers.target

--- a/etc/systemd/system/tedge-mapper-c8y.service
+++ b/etc/systemd/system/tedge-mapper-c8y.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format.
 After=syslog.target network.target mosquitto.service
+Wants=tedge-cert-renewer@c8y.timer
 
 [Service]
 User=tedge

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -118,6 +118,13 @@ if [ ! -f /etc/systemd/system/tedge-mapper-c8y.service ]; then
     wget -O - https://raw.githubusercontent.com/thin-edge/tedge-actia-tgur/main/etc/systemd/system/tedge-mapper-c8y.service > /etc/systemd/system/tedge-mapper-c8y.service
 fi
 
+if [ ! -f /etc/systemd/system/tedge-cert-renewer.target ]; then
+    echo "Downloading service definition: tedge-cert-renewer units" >&2
+    wget -O - https://raw.githubusercontent.com/thin-edge/tedge-actia-tgur/main/etc/systemd/system/tedge-cert-renewer@.service > /etc/systemd/system/tedge-cert-renewer@.service
+    wget -O - https://raw.githubusercontent.com/thin-edge/tedge-actia-tgur/main/etc/systemd/system/tedge-cert-renewer@.timer > /etc/systemd/system/tedge-cert-renewer@.timer
+    wget -O - https://raw.githubusercontent.com/thin-edge/tedge-actia-tgur/main/etc/systemd/system/tedge-cert-renewer.target > /etc/systemd/system/tedge-cert-renewer.target
+fi
+
 # reload service definitions
 systemctl daemon-reload
 


### PR DESCRIPTION
Add the tedge-cert-renewer systemd service definitions to configure the auto renewal of the certificates.

The tedge-cert-renewer.timer will be automatically launched when starting the tedge-mapper-c8y service. The `tedge-cert-renewer@c8y.timer` will periodically trigger the `tedge-cert-renewer@c8y.service` which will proactively renew a soon-to-expire device certificate (if the Cumulocity CA has issued the device's certificate).

Resolves https://github.com/thin-edge/tedge-actia-tgur/issues/11