### PR TITLE
fix: add missing configuration file plugin

### DIFF
--- a/com.thin-edge.app/config-plugins/file
+++ b/com.thin-edge.app/config-plugins/file
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tedge run tedge-file-config-plugin "$@"

--- a/com.thin-edge.app/tedge.toml
+++ b/com.thin-edge.app/tedge.toml
@@ -7,5 +7,8 @@ path = "/media/apps/com.thin-edge.app/data"
 [log]
 plugin_paths = ["/media/apps/com.thin-edge.app/log-plugins", "/usr/share/tedge/log-plugins"]
 
+[configuration]
+plugin_paths = ["/media/apps/com.thin-edge.app/config-plugins", "/usr/share/tedge/config-plugins"]
+
 [diag]
 plugin_paths = ["/media/apps/com.thin-edge.app/diag-plugins", "/usr/share/tedge/diag-plugins"]


### PR DESCRIPTION
Adding missing configuration file plugin which was introduced in thin-edge.io 2.0.0